### PR TITLE
Clean up func io decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,12 +16,15 @@ utilipy.tests.helper
 
   + phase-wrap support
 
-
 utilipy.utils.pickle
 ^^^^^^^^^^^^^^^^^^^^
 
 - Added configuration for using dill over pickle [#26]
   Changed default from True to False
+
+utilipy.decorators
+^^^^^^^^^^^^^^^^^^
+
 
 
 API Changes
@@ -39,8 +42,10 @@ API Changes
 - Module ``ipython`` is not imported to top-level namespace [#20]
   because this is not always used in an ipython environment.
 
-
 - Changed default from True to False in dill-over-pickle config [#26]
+  
+- Change argument ``dtypeDecoratorBase`` for iterating over all function
+  arguments from 'all'  to `~Ellipsis` [#19]
 
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,7 @@ API Changes
   because this is not always used in an ipython environment.
 
 - Changed default from True to False in dill-over-pickle config [#26]
-  
+
 - Change argument ``dtypeDecoratorBase`` for iterating over all function
   arguments from 'all'  to `~Ellipsis` [#19]
 

--- a/utilipy/decorators/baseclass.py
+++ b/utilipy/decorators/baseclass.py
@@ -224,7 +224,7 @@ class DecoratorBaseMeta(type):
         name: str
         param: inspect.Parameter
         for i, (name, param) in enumerate(callsig.parameters.items()):
-            # only key-word only args (most since added var_positional)
+            # only keyword-only args (most since added var_positional)
             if (name in dct["__kwdefaults__"]) and (  # yup
                 param.kind == inspect.KEYWORD_ONLY
             ):  # key-word
@@ -463,7 +463,7 @@ class DecoratorBaseClass(metaclass=DecoratorBaseMeta):
 
         # replacing defaults if in __kwdefaults__
         for i, (name, param) in enumerate(self._callsig.parameters.items()):
-            # only key-word only args (most since added var_positional)
+            # only keyword-only args (most since added var_positional)
             if (
                 (name in self.__kwdefaults__)  # yup
                 and (param.kind == inspect.KEYWORD_ONLY)  # key-word

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -451,7 +451,7 @@ class dtypeDecoratorBase:
         - iterable: convert arguments at index speficied in iterable
             ex: [0, 2] converts arguments 0 & 2
         - slice: convert all arguments specified by slicer
-    outargs : Ellipsis or iterable or tuple or slice (optional)
+    outargs : Ellipsis or iterable or tuple or slice or None (optional)
         - None (default), does nothing
         - iterable: convert arguments at index speficied in iterable
             ex: [0, 2] converts arguments 0 & 2

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -82,12 +82,12 @@ def store_function_input(
         Parameters
         ----------
         store_inputs: bool
-            whether to store function inputs in a BoundArguments instance
-            default {store_inputs}
+            whether to store function inputs in a `~inspect.BoundArguments`
+            instance default {store_inputs}
 
         Returns
         -------
-        inputs: BoundArguments
+        inputs: `~inspect.BoundArguments`
             the inputs to ``{wrapped_function}``
             only returned if `store_inputs` is True
             other returned values are in now in a tuple

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -18,7 +18,6 @@ import typing as T
 
 # THIRD PARTY
 import numpy as np
-from typing_extensions import Literal
 
 # PROJECT-SPECIFIC
 from utilipy.utils import functools, inspect

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -230,8 +230,7 @@ def add_folder_backslash(
 
 def random_generator_from_seed(
     function: T.Callable = None,
-    seed_names: T.Union[str, T.Sequence[str]] = ["random", "random_seed"],
-    *,
+    seed_names: T.Union[str, T.Sequence[str]] = ("random", "random_seed"),
     generator: T.Callable = np.random.RandomState,
     raise_if_not_int: bool = False,
 ):
@@ -242,12 +241,12 @@ def random_generator_from_seed(
     function : types.FunctionType or None (optional)
         the function to be decoratored
         if None, then returns decorator to apply.
-    seed_names : list (optional, key-word only)
+    seed_names : list (optional)
         possible parameter names for the random seed
-    generator : ClassType (optional, key-word only)
+    generator : ClassType (optional)
         ex :class:`numpy.random.default_rng`, :class:`numpy.random.RandomState`
 
-    raise_if_not_int : bool (optional, key-word only)
+    raise_if_not_int : bool (optional, keyword-only)
         raise TypeError if seed argument is not an int.
 
     Returns

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -132,7 +132,7 @@ def add_folder_backslash(
     arguments : list of string or int, optional
         arguments to which to append '/', if not already present
         strings are names of arguments.
-        Can also be int, which only applies to args
+        Can also be int, which only applies to args.
 
     Returns
     -------
@@ -170,7 +170,7 @@ def add_folder_backslash(
 
     """
     if isinstance(arguments, (str, int)):  # recast as tuple
-        arguments = (arguments, )
+        arguments = (arguments,)
 
     if function is None:  # allowing for optional arguments
         return functools.partial(
@@ -193,18 +193,25 @@ def add_folder_backslash(
             default {store_inputs}
 
         """
+        # bind args & kwargs to function
         ba = sig.bind_partial(*args, **kw)
+        ba.apply_defaults()
 
-        for name in arguments:
-            if not isinstance(ba.arguments[name], str):
+        for name in arguments:  # iter through args
+            # first check it's a string
+            if not isinstance(ba.arguments[name], (str, bytes)):
                 continue
+            else:
+                str_type = type(ba.arguments[name])  # get string type
 
-            elif isinstance(name, int):  # only applies to args
-                if not ba.args[name].endswith("/"):
-                    ba.args[name] += "/"
+            backslash = str_type("/")  # so we can work with any type
+
+            if isinstance(name, int):  # only applies to args
+                if not ba.args[name].endswith(backslash):
+                    ba.args[name] += backslash
             elif isinstance(name, str):  # args or kwargs
-                if not ba.arguments[name].endswith("/"):
-                    ba.arguments[name] += "/"
+                if not ba.arguments[name].endswith(backslash):
+                    ba.arguments[name] += backslash
             else:
                 raise TypeError("elements of `args` must be int or str")
 

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -231,6 +231,7 @@ def add_folder_backslash(
 def random_generator_from_seed(
     function: T.Callable = None,
     seed_names: T.Union[str, T.Sequence[str]] = ["random", "random_seed"],
+    *,
     generator: T.Callable = np.random.RandomState,
     raise_if_not_int: bool = False,
 ):
@@ -238,15 +239,15 @@ def random_generator_from_seed(
 
     Parameters
     ----------
-    function : types.FunctionType or None, optional
+    function : types.FunctionType or None (optional)
         the function to be decoratored
         if None, then returns decorator to apply.
-    seed_names : list, optional
+    seed_names : list (optional, key-word only)
         possible parameter names for the random seed
-    generator : ClassType, optional
+    generator : ClassType (optional, key-word only)
         ex :class:`numpy.random.default_rng`, :class:`numpy.random.RandomState`
 
-    raise_if_not_int : bool, optional
+    raise_if_not_int : bool (optional, key-word only)
         raise TypeError if seed argument is not an int.
 
     Returns
@@ -263,7 +264,7 @@ def random_generator_from_seed(
 
     """
     if isinstance(seed_names, str):  # correct a bare string to list
-        seed_names = [seed_names]
+        seed_names = (seed_names, )
 
     if function is None:  # allowing for optional arguments
         return functools.partial(

--- a/utilipy/decorators/func_io.py
+++ b/utilipy/decorators/func_io.py
@@ -22,6 +22,7 @@ from typing_extensions import Literal
 
 # PROJECT-SPECIFIC
 from utilipy.utils import functools, inspect
+from utilipy.utils.typing import EllipsisType
 
 ##############################################################################
 # CODE
@@ -490,8 +491,8 @@ class dtypeDecoratorBase:
     def __new__(
         cls,
         func: T.Callable = None,
-        inargs: T.Union[Ellipsis, slice, T.Iterable, None] = None,
-        outargs: T.Union[Ellipsis, slice, T.Iterable, None] = None,
+        inargs: T.Union[EllipsisType, slice, T.Iterable, None] = None,
+        outargs: T.Union[EllipsisType, slice, T.Iterable, None] = None,
     ):
         self = super().__new__(cls)  # making instance of self
 
@@ -516,8 +517,8 @@ class dtypeDecoratorBase:
 
     def __init__(
         self,
-        inargs: T.Union[Ellipsis, slice, T.Iterable, None] = None,
-        outargs: T.Union[Ellipsis, slice, T.Iterable, None] = None,
+        inargs: T.Union[EllipsisType, slice, T.Iterable, None] = None,
+        outargs: T.Union[EllipsisType, slice, T.Iterable, None] = None,
     ) -> None:
         super().__init__()
 

--- a/utilipy/utils/functools.py
+++ b/utilipy/utils/functools.py
@@ -249,7 +249,7 @@ def __update_wrapper_update_sig(
                 raise TypeError(
                     f"{param.name} must match kind in function signature"
                 )
-            # can only merge key-word only
+            # can only merge keyword-only
             if param.kind == _nspct.KEYWORD_ONLY:
                 signature = signature.modify_parameter(
                     param.name,
@@ -264,7 +264,7 @@ def __update_wrapper_update_sig(
 
         # add to signature
         else:
-            # can only merge key-word only
+            # can only merge keyword-only
             if param.kind == _nspct.KEYWORD_ONLY:
                 signature = signature.insert_parameter(
                     signature.index_end_keyword_only, param
@@ -431,7 +431,7 @@ def update_wrapper(
 
         # for docstring
         for param in wrapper_sig.parameters.values():
-            # can only merge key-word only
+            # can only merge keyword-only
             if param.kind == _nspct.KEYWORD_ONLY:
                 _doc_fmt[param.name] = param.default
 

--- a/utilipy/utils/inspect.py
+++ b/utilipy/utils/inspect.py
@@ -194,8 +194,8 @@ def getfullerargspec(func: T.Callable) -> FullerArgSpec:
         defargs          : arguments with defaults
         defaults         : dictionary of defaults to `defargs`
         varargs          : variable arguments (args)
-        kwonlyargs       : key-word only arguments
-        kwonlydefaults   : key-word only argument defaults
+        kwonlyargs       : keyword-only arguments
+        kwonlydefaults   : keyword-only argument defaults
         varkw            : variable key-word arguments (kwargs)
         annotations      : function annotations
         docstring        : function docstring
@@ -317,7 +317,7 @@ def get_defaults_from_signature(signature: Signature) -> tuple:
 
 
 def get_kwdefaults_from_signature(signature: Signature) -> dict:
-    """Get key-word only defaults from Signature object.
+    """Get keyword-only defaults from Signature object.
 
     Parameters
     ----------
@@ -861,7 +861,7 @@ class FullerSignature(Signature):
 
     @property
     def __kwdefaults__(self) -> T.Optional[dict]:
-        """Get key-word only defaults.
+        """Get keyword-only defaults.
 
         Returns
         -------
@@ -882,7 +882,7 @@ class FullerSignature(Signature):
 
     @property
     def kwdefaults(self) -> T.Optional[dict]:
-        """Get key-word only defaults.
+        """Get keyword-only defaults.
 
         Returns
         -------
@@ -903,7 +903,7 @@ class FullerSignature(Signature):
 
     @property
     def kwonlydefaults(self) -> T.Optional[dict]:
-        """Get key-word only defaults.
+        """Get keyword-only defaults.
 
         Returns
         -------

--- a/utilipy/utils/typing.py
+++ b/utilipy/utils/typing.py
@@ -5,6 +5,7 @@
 __all__ = [
     # compat
     "OrderedDictType",
+    "EllipsisType",
     # numpy
     "array_like",
     # Astropy


### PR DESCRIPTION
## Description

Proposed API change : 'all' to Ellipsis in `dtypeDecoratorBase`


## PR Checklist

- [x] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [x] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [x] Give a detailed description of the PR above.
- [x] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [x] Add tests, if applicable, to ensure code coverage never decreases.
- [x] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [x] Ensure linear history by rebasing, when requested by the maintainer.
