### PR TITLE
[BUG] fix docs build problem

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ docs =
     sphinx-astropy
     nbsphinx
     jupyter_client
-    sphinxcontrib-bibtex
+    sphinxcontrib-bibtex < 2.0.0
 
 
 [options.package_data]


### PR DESCRIPTION
## Description

Docs don't build with new version of sphinxcontrib-bibtex.
Temporarily pinning to pre-version 2.0


## PR Checklist

- [x] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [x] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [x] Give a detailed description of the PR above.
- [x] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [x] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [x] Ensure linear history by rebasing, when requested by the maintainer.
